### PR TITLE
Ensure capture starts session before saving find

### DIFF
--- a/app/src/shared/SessionContext.tsx
+++ b/app/src/shared/SessionContext.tsx
@@ -10,7 +10,7 @@ type SessionContextValue = {
   endSession: (name?: string) => Promise<Session | null>;
   endSessionById: (sessionId: string, name?: string) => Promise<Session | null>;
   refreshSessions: () => Promise<void>;
-  addFindToActiveSession: (findId: string) => Promise<void>;
+  addFindToActiveSession: (findId: string, sessionIdOverride?: string) => Promise<void>;
 };
 
 const SessionContext = createContext<SessionContextValue | undefined>(undefined);
@@ -76,9 +76,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   );
 
   const addFindToActiveSession = useCallback(
-    async (findId: string) => {
-      if (!activeSession) return;
-      await addFindToSession(activeSession.id, findId);
+    async (findId: string, sessionIdOverride?: string) => {
+      const sessionId = sessionIdOverride ?? activeSession?.id;
+      if (!sessionId) return;
+      await addFindToSession(sessionId, findId);
       await refreshSessions();
     },
     [activeSession, refreshSessions]


### PR DESCRIPTION
## Summary
- Context: Phase 1 (Capture Core). Start or reuse a session at the beginning of capture so the first offline save is linked immediately
- Use the freshly started session ID when inserting finds and when linking them to the session ledger
- Allow linking a find to a specific session ID through the session context to avoid stale active session checks

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ddb3f3a083318c6856ed41c0d61b)