### PR TITLE
Make review prompt opt-in with capture toast

### DIFF
--- a/app/src/features/capture/SessionLedger.tsx
+++ b/app/src/features/capture/SessionLedger.tsx
@@ -8,6 +8,7 @@ type Props = {
   refreshKey: number;
   onUpdated?: () => void;
   onRequestReview?: () => void;
+  onKept?: () => void;
 };
 
 // Simple ledger: pick keeps, then review.
@@ -31,6 +32,9 @@ export function SessionLedger({ refreshKey, onUpdated, onRequestReview }: Props)
 
   const toggleKeep = async (id: string, current: boolean) => {
     await updateFindMetadata(id, { favorite: !current });
+    if (!current && onKept) {
+      onKept();
+    }
     // Trigger refreshKey increment in parent to reload us and update UI
     if (onUpdated) onUpdated();
     else load();


### PR DESCRIPTION
## Summary
- Phase 1: Add a post-capture toast with auto-prompt toggle so review options stay opt-in
- Only surface the NextActionPrompt when the user enables it (via kept stars or cadence) and auto-dismiss it after a short delay
- Let starring a find arm the review prompt while keeping the capture loop fast for consecutive snaps

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ddb642e083319244b655e2e1c522)