### PR TITLE
Add provider validation and secret checks for identify function

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -38,5 +38,4 @@ curl -X POST https://identify-yq7xepmata-uc.a.run.app \
 ```
 
 ## Response
-Strict JSON matching `rock_id_result` schema (see `rockIdSchema.js`). The function validates the model output against this schema and returns 400 on missing images, 405 on non-POST, 500 on generation/validation errors.
-*** End Patch***고 json code? wrong format. apply_patch expects plain text. revert. Can't apply. Need reapply correct. Let's add README with apply_patch plain. Let's do. end patch markers etc. Don't use JSON. We'll apply_patch. Let's redo.  
+Strict JSON matching `rock_id_result` schema (see `rockIdSchema.js`). The function validates the model output against this schema and returns 400 on missing images, 405 on non-POST, and 500 on generation/validation errors.

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,10 @@ function clampImages(body) {
 }
 
 async function callOpenAI({ userPrompt, images }) {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error('Missing OPENAI_API_KEY secret');
+  }
+
   const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const content = [{ type: 'input_text', text: userPrompt }];
   for (const img of images) {
@@ -68,6 +72,10 @@ function toGeminiParts({ userPrompt, images }) {
 }
 
 async function callGemini({ userPrompt, images }) {
+  if (!process.env.GEMINI_API_KEY) {
+    throw new Error('Missing GEMINI_API_KEY secret');
+  }
+
   // Direct REST call to v1 Gemini to avoid client version issues.
   const apiKey = process.env.GEMINI_API_KEY;
   const url = `https://generativelanguage.googleapis.com/v1/models/gemini-2.5-flash:generateContent?key=${apiKey}`;
@@ -113,6 +121,9 @@ exports.identify = onRequest(
 
     const body = req.body || {};
     const provider = (body.provider || 'openai').toLowerCase();
+    if (!['openai', 'gemini'].includes(provider)) {
+      return res.status(400).json({ error: 'Unsupported provider', provider });
+    }
     const images = clampImages(body);
     if (images.length === 0) {
       return res.status(400).json({ error: 'No images provided' });


### PR DESCRIPTION
## Summary
- Context: Phase 3 — Rock Buddy (AI). Add provider allowlist for the identify endpoint and return a clear 400 when an unsupported provider is requested.
- Detect missing OPENAI_API_KEY or GEMINI_API_KEY secrets before calling model APIs so failures surface as actionable errors.
- Clean the identify README by removing stray patch text and clarifying the response/requirements.

## Testing
- npm run lint (functions)
- npm run lint (app)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952deaaaa088331889644266f3fcabc)